### PR TITLE
Add basic validation to getToken()

### DIFF
--- a/src/GrantType/GrantTypeBase.php
+++ b/src/GrantType/GrantTypeBase.php
@@ -88,6 +88,17 @@ abstract class GrantTypeBase implements GrantTypeInterface
 
         $response = $this->client->post($config['token_url'], $requestOptions);
         $data = $response->json();
+        
+        if(!isset($data['access_token']) or !isset($data['token_type'])) {
+            $message = 'Invalid response from server.';
+            if(isset($data['error'])) {
+                $message.= ' Error: ' . $data['error'] . '.';
+            }
+            if(isset($data['error_description'])) {
+                $message.= ' Description: ' . $data['error_description'] . '.';
+            }
+            throw new \RuntimeException($message);
+        }
 
         return new AccessToken($data['access_token'], $data['token_type'], $data);
     }


### PR DESCRIPTION
When the OAuth2 Authorization Server returns a HTTP 200 OK, the JSON response should still be validated. This protects from the PHP NOTICE errors that are triggered when 'access_token' and/or 'token_type' are missing from $data. By throwing an exception, it becomes clear to the user where things went wrong - especially if the OAuth2 server sets the 'error' and 'error description' properties (like many implementations do).